### PR TITLE
feat: Add AWS KMS encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ await s3db.moveFullyQualified('myuserdatabucket/users/U12345.json', 'myuserdatab
 // qualified paths
 ```
 
+## Server-Side Encryption with KMS
+
+S3DB supports server-side encryption using AWS KMS keys. You can specify either a KMS key ID or a KMS alias when creating an S3DB instance:
+
+```javascript
+// Create an S3DB instance with KMS encryption (using either key ID or alias)
+const s3db = new S3DB('myuserdatabucket', 'users', '1234abcd-12ab-34cd-56ef-1234567890ab'); // Using key ID
+// OR
+const s3db = new S3DB('myuserdatabucket', 'users', 'alias/my-kms-key'); // Using alias
+
+// Write and read data - encryption is handled automatically
+const userData = { name: 'John Doe', email: 'john@example.com' };
+await s3db.put('user123', userData);
+const retrieved = await s3db.get('user123');
+```
+
 ## Working with Blobs
 
 In addition to the standard methods for working with JSON objects, S3DB also provides methods for working with blobs of any type. These methods are:

--- a/README.md
+++ b/README.md
@@ -131,10 +131,14 @@ await s3db.deleteRaw(blobKey);
 
 ## Create Testing Infrastructure
 
-This is to create the testin S3 bucket necessary to run unit tests.  Requires the AWS CLI and active AWS credentials to be configured in the environment.
+This is to create the testing S3 bucket necessary to run unit tests. Requires the AWS CLI and active AWS credentials to be configured in the environment.
 
 ```shell
+# Create a new stack
 aws cloudformation create-stack --stack-name S3DBUnitTestStack --template-body file://cloudformation.yml
+
+# Update an existing stack
+aws cloudformation update-stack --stack-name S3DBUnitTestStack --template-body file://cloudformation.yml
 ```
 
 ## Test

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -36,3 +36,21 @@ Resources:
             Condition:
               StringLike:
                 's3:x-amz-grant-read': '*'
+  UnittestKMSKey:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: 'KMS key for S3DB unit tests'
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: 'Enable IAM User Permissions'
+            Effect: 'Allow'
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+  UnittestKMSKeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: 'alias/s3db-unittest-key'
+      TargetKeyId: !Ref UnittestKMSKey

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dwkerwin/s3db",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "",
     "main": "index.js",
     "author": "dwkerwin@gmail.com",


### PR DESCRIPTION
Add support for server-side encryption using AWS KMS keys. Users can now specify 
either a KMS key ID or alias when creating an S3DB instance. All S3 operations 
will automatically use the specified key for encryption.

- Add kmsKeyId parameter to S3DB constructor
- Update put/putRaw methods to include KMS encryption parameters
- Add KMS key and alias to CloudFormation test resources
- Add tests for KMS encrypted objects
- Update README with KMS encryption documentation

The KMS configuration is optional - existing code will continue to work without 
changes. When a KMS key is specified, all write operations will automatically 
use that key for encryption.